### PR TITLE
Fix/documentation inconsistencies

### DIFF
--- a/docs/first-deploy.md
+++ b/docs/first-deploy.md
@@ -57,10 +57,10 @@ Here we applied deployment, service and ingress separately. Sometimes this makes
 
 ### Time to test
 
-Use your browser curl to check <a href="https://the.vps.address/foo" target="_blank">http://the.vps.address/foo</a>
+Use your browser curl to check <a href="https://example.com/foo" target="_blank">http://example.com/foo</a>
 
 ```bash
-curl http://the.vps.ip.here/foo
+curl http://example.com/foo
 ```
 
 ```bash
@@ -107,7 +107,6 @@ To add https support, you need to either use cert-manager and add some tls-info 
 You need first to deploy [cert-manager](https-cert-manager-letsencrypt.md).
 
 ### Ingress
-
 Then you can apply the ingress.
 
 ```bash

--- a/docs/install-setup.md
+++ b/docs/install-setup.md
@@ -67,6 +67,12 @@ The first step is to configure one (or more) manager nodes.
 --8<-- "./scripts/git_clone_k3s.rocks.txt"
 ```
 
+After cloning the repository, change into the manifest directory:
+
+```bash
+cd k3s.rocks/manifests 
+```
+
 ### apply vs cat vs curl
 
 If you prefer not to download them, you can also curl and pipe them directly into kubectl apply -f. Just replace the cat command, with a curl command with the correct url, like this:

--- a/manifests/registry-localstorage.yaml
+++ b/manifests/registry-localstorage.yaml
@@ -29,6 +29,13 @@ spec:
         image: registry:2
         ports:
         - containerPort: 5000
+        volumeMounts:
+        - name: my-registry-localstorage-volume
+          mountPath: /var/lib/registry
+      volumes:
+      - name: my-registry-localstorage-volume
+        persistentVolumeClaim:
+          claimName: registry-pvc
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/manifests/whoami/whoami-ingress-tls.yaml
+++ b/manifests/whoami/whoami-ingress-tls.yaml
@@ -17,7 +17,7 @@ spec:
               service:
                 name: whoami
                 port:
-                  number: 80
+                  number: 5678
   tls:
     - secretName: whoami-tls
       hosts:

--- a/scripts/apply_traefik_redirect_middleware.txt
+++ b/scripts/apply_traefik_redirect_middleware.txt
@@ -1,1 +1,1 @@
-kubectl apply -f ./manifests/traefik-https-redirect-middleware.yaml
+kubectl apply -f ./traefik-https-redirect-middleware.yaml

--- a/scripts/whoami_deployment.txt
+++ b/scripts/whoami_deployment.txt
@@ -1,1 +1,1 @@
-kubectl apply -f ./manifests/whoami/whoami-deployment.yaml 
+kubectl apply -f ./whoami/whoami-deployment.yaml 

--- a/scripts/whoami_ingress.txt
+++ b/scripts/whoami_ingress.txt
@@ -1,1 +1,1 @@
-kubectl apply -f ./manifests/whoami/whoami-ingress.yaml
+kubectl apply -f ./whoami/whoami-ingress.yaml

--- a/scripts/whoami_service.txt
+++ b/scripts/whoami_service.txt
@@ -1,1 +1,1 @@
-kubectl apply -f ./manifests/whoami/whoami-service.yaml
+kubectl apply -f ./whoami/whoami-service.yaml


### PR DESCRIPTION
Fixes manifest paths in `kubectl apply` commands to always assume user
to be in manifest directory already.

Change whoami-tls-ingress to point to correct service port.

Add persistent localstorage for registry setup.

Fixes https://github.com/askblaker/k3s.rocks/issues/3