### PR TITLE
Fix traefik dashboard service instance selector name

### DIFF
--- a/manifests/traefik-dashboard-service.yaml
+++ b/manifests/traefik-dashboard-service.yaml
@@ -14,5 +14,5 @@ spec:
     targetPort: traefik
     protocol: TCP
   selector:
-    app.kubernetes.io/instance: traefik
+    app.kubernetes.io/instance: traefik-kube-system
     app.kubernetes.io/name: traefik


### PR DESCRIPTION
my k3s version

```shell
$ k3s -version
k3s version v1.26.3+k3s1 (01ea3ff2)
go version go1.19.7
```

And the traefik instance label is `app.kubernetes.io/instance=traefik-kube-system`
```shell
$ kubectl describe pod -n kube-system traefik-6b695786fd-58d4t
Name:                 traefik-6b695786fd-58d4t
Namespace:            kube-system
Priority:             2000000000
Priority Class Name:  system-cluster-critical
Service Account:      traefik
Node:                 dream-master/10.66.66.1
Start Time:           Thu, 13 Apr 2023 15:10:30 +0000
Labels:               app.kubernetes.io/instance=traefik-kube-system
                      app.kubernetes.io/managed-by=Helm
....
```


