### PR TITLE
replace deprecated whoami image

### DIFF
--- a/manifests/whoami/whoami-deployment.yaml
+++ b/manifests/whoami/whoami-deployment.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
         - name: whoami
-          image: containous/whoami:v1.5.0
+          image: traefik/whoami:v1.9.0
           ports:
             - containerPort: 80


### PR DESCRIPTION
Hi, [`containous/whoami`](https://hub.docker.com/r/containous/whoami) image on dockerhub is deprecated.

Replace it with the recommended substitution.