### PR TITLE
fix: registry no longer support MD5

### DIFF
--- a/docs/private-registry.md
+++ b/docs/private-registry.md
@@ -27,7 +27,7 @@ metadata:
   namespace: default
 data:
   users: |2
-    $(htpasswd -bn $REGISTRY_USERNAME $REGISTRY_PASSWORD | base64)
+    $(htpasswd -Bbn $REGISTRY_USERNAME $REGISTRY_PASSWORD | base64)
 EOF
 ```
 


### PR DESCRIPTION
According to this [bug report](https://github.com/distribution/distribution/issues/2817) and my own feedback, you must use a salted hash version, otherwise, authentication will not work. see.