### PR TITLE
update ingress class annotation

### DIFF
--- a/manifests/alert-manager-ingress.yaml
+++ b/manifests/alert-manager-ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: alert-manager-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.middlewares: default-my-basic-auth@kubernetescrd
 spec:

--- a/manifests/argocd-tmp-ingress.yaml
+++ b/manifests/argocd-tmp-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: argocd-ingress
   namespace: argocd
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   rules:

--- a/manifests/custom-ephemeral-container.yml
+++ b/manifests/custom-ephemeral-container.yml
@@ -35,7 +35,7 @@ kind: Ingress
 metadata:
   name: $APPNAME-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   rules:

--- a/manifests/erpnext_tls_ingress.yaml
+++ b/manifests/erpnext_tls_ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: erpnext-tls-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd, default-replace-host@kubernetescrd
 spec:

--- a/manifests/ghost-ephemeral.yaml
+++ b/manifests/ghost-ephemeral.yaml
@@ -45,7 +45,7 @@ kind: Ingress
 metadata:
   name: ghost-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   rules:

--- a/manifests/ghost-localstorage.yaml
+++ b/manifests/ghost-localstorage.yaml
@@ -52,7 +52,7 @@ kind: Ingress
 metadata:
   name: ghost-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   rules:

--- a/manifests/ghost-longhorn.yaml
+++ b/manifests/ghost-longhorn.yaml
@@ -52,7 +52,7 @@ kind: Ingress
 metadata:
   name: ghost-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   rules:

--- a/manifests/grafana-ingress.yaml
+++ b/manifests/grafana-ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: grafana-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.middlewares: default-my-basic-auth@kubernetescrd
 spec:

--- a/manifests/guestbook/guestbook-ui-ingress.yaml
+++ b/manifests/guestbook/guestbook-ui-ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: traefik-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   rules:

--- a/manifests/keel.yaml
+++ b/manifests/keel.yaml
@@ -99,7 +99,7 @@ kind: Ingress
 metadata:
   name: keel-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.middlewares: default-my-basic-auth@kubernetescrd
 spec:

--- a/manifests/longhorn-ui-ingress.yaml
+++ b/manifests/longhorn-ui-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: longhorn-ingress
   namespace: longhorn-system
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.middlewares: default-my-basic-auth@kubernetescrd
 

--- a/manifests/plausible-localstorage.yaml
+++ b/manifests/plausible-localstorage.yaml
@@ -249,7 +249,7 @@ kind: Ingress
 metadata:
   name: plausible-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   rules:

--- a/manifests/postgres-longhorn.yaml
+++ b/manifests/postgres-longhorn.yaml
@@ -61,7 +61,7 @@ kind: Ingress
 metadata:
   name: postgres-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
 spec:
   rules:
   - host: postgres.${DOMAIN}

--- a/manifests/prometheus-ingress.yaml
+++ b/manifests/prometheus-ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: prometheus-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.middlewares: default-my-basic-auth@kubernetescrd
 spec:

--- a/manifests/registry-ephemeral.yaml
+++ b/manifests/registry-ephemeral.yaml
@@ -35,7 +35,7 @@ kind: Ingress
 metadata:
   name: registry-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.middlewares: default-registry-cors@kubernetescrd, default-registry-basic-auth@kubernetescrd
 spec:

--- a/manifests/registry-localstorage.yaml
+++ b/manifests/registry-localstorage.yaml
@@ -42,7 +42,7 @@ kind: Ingress
 metadata:
   name: registry-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.middlewares: default-registry-cors@kubernetescrd, default-registry-basic-auth@kubernetescrd
 spec:

--- a/manifests/registry-longhorn.yaml
+++ b/manifests/registry-longhorn.yaml
@@ -42,7 +42,7 @@ kind: Ingress
 metadata:
   name: registry-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.middlewares: default-registry-cors@kubernetescrd, default-registry-basic-auth@kubernetescrd
 spec:

--- a/manifests/registry-ui.yaml
+++ b/manifests/registry-ui.yaml
@@ -44,7 +44,7 @@ kind: Ingress
 metadata:
   name: registry-ui-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
     # use this if you want basic auth on the UI
     # you have to use the registry credential any way

--- a/manifests/system-info-web.yaml
+++ b/manifests/system-info-web.yaml
@@ -37,7 +37,7 @@ kind: Ingress
 metadata:
   name: sysinfo-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   rules:

--- a/manifests/traefik-dashboard-ingress-basic-auth.yaml
+++ b/manifests/traefik-dashboard-ingress-basic-auth.yaml
@@ -4,7 +4,7 @@ metadata:
   name: traefik-ingress
   namespace: kube-system
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     traefik.ingress.kubernetes.io/router.middlewares: default-my-basic-auth@kubernetescrd
 spec:
   rules:

--- a/manifests/traefik-dashboard-ingress.yaml
+++ b/manifests/traefik-dashboard-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: traefik-ingress
   namespace: kube-system
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
 spec:
   rules:
     - host: traefik.${DOMAIN}

--- a/manifests/traefik-dashboard-tmp-ingress.yaml
+++ b/manifests/traefik-dashboard-tmp-ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: traefik-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   rules:

--- a/manifests/whoami/whoami-ingress-tls.yaml
+++ b/manifests/whoami/whoami-ingress-tls.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: whoami-tls-ingress
   annotations:
-    kubernetes.io/ingress.class: traefik
+    spec.ingressClassName: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.middlewares: default-redirect-https@kubernetescrd
 spec:


### PR DESCRIPTION
deprecated:  `kubernetes.io/ingress.class: traefik`  
updated to:  `spec.ingressClassName: traefik`  

closes #26 