### PR TITLE
Add externalTrafficPolicy: Local to load balancer

### DIFF
--- a/manifests/technitium-localstorage.yaml
+++ b/manifests/technitium-localstorage.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: technitium
-          image: technitium/dns-server:11.1.1
+          image: technitium/dns-server:13.4.3
           volumeMounts:
             - name: technitium-volume
               mountPath: /etc/dns
@@ -56,4 +56,5 @@ spec:
       protocol: TCP
   selector:
     app: technitium
+  externalTrafficPolicy: Local
   type: LoadBalancer


### PR DESCRIPTION
This adds the `externalTrafficPolicy: Local` to the load balancer. Without this, all the requests to technitium look like they are from one IP address. Here's a reference: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip

I also bumped the version of the server.